### PR TITLE
Fix a typo in file 'rc.lua'

### DIFF
--- a/rc.lua
+++ b/rc.lua
@@ -936,7 +936,7 @@ awful.rules.rules = {
     rule = { class = "Firefox", instance = "firefox" },
     properties = { floating = true }
   }, {
-    -- popup from FireGuesture with mouse wheel
+    -- popup from FireGestures with mouse wheel
     rule = {
       class = "Firefox",
       skip_taskbar = true,
@@ -950,7 +950,7 @@ awful.rules.rules = {
     rule = { class = "Wireshark", name = "Wireshark" }, -- wireshark startup window
     properties = { floating = true }
   }, {
-    rule_any = { 
+    rule_any = {
       instance = {'TM.exe', 'QQ.exe'},
     },
     properties = {


### PR DESCRIPTION
Hello @lilydjwg ,

Appreciate your great job! :rose: However, I have found a typo in file 'rc.lua'. This pull request should fix the following typo:
1. 'FireGuesture' should be 'FireGestures', see https://addons.mozilla.org/en-US/firefox/addon/firegestures/ for details.
2. Delete a trailing space.

Do you agree with me? Hope for your reply!

Yours sincerely! :bow:
